### PR TITLE
Installing mpi4py in Eman's python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Default installation path assumed is ``software/em/locscale-0.1``,
 if you want to change it, set *LOCSCALE_HOME* in ``scipion.conf``
 file to the folder where the LocScale is installed.
 LocScale uses EMAN2 libraries, so you need to provide existing EMAN2
-installation path by setting *LOCSCALE_EMAN_HOME* variable
+installation path by setting *EMAN2_HOME* variable
 (default eman-2.3) in the config file.
 
 Note: **mpi4py** will be installed in the Eman's python

--- a/README.rst
+++ b/README.rst
@@ -24,3 +24,6 @@ Alternatively, in devel mode:
 .. code-block::
 
     scipion installp -p local/path/to/scipion-em-locscale --devel
+
+
+Note: **mpi4py** will be installed in the Eman's python

--- a/locscale/__init__.py
+++ b/locscale/__init__.py
@@ -72,6 +72,10 @@ class Plugin(pyworkflow.em.Plugin):
 
         env.addPackage('locscale', version='0.1',
                        tar='locscale-0.1.tgz',
+                       commands=[('echo "installing mpi4py in eman2" ; '
+                                  'export %s ; pip install mpi4py' % EMAN_ENV_STR,
+                                  emanPlugin.getHome('lib', 'python2.7',
+                                                     'site-packages', 'mpi4py'))],
                        default=True)
 
 

--- a/locscale/__init__.py
+++ b/locscale/__init__.py
@@ -45,8 +45,6 @@ class Plugin(pyworkflow.em.Plugin):
     @classmethod
     def _defineVariables(cls):
         cls._defineEmVar(LOCSCALE_HOME, 'locscale-0.1')
-        cls._defineEmVar(LOCSCALE_EMAN_HOME, 'eman-2.3')
-
 
     @classmethod
     def getEnviron(cls):

--- a/locscale/__init__.py
+++ b/locscale/__init__.py
@@ -67,7 +67,7 @@ class Plugin(pyworkflow.em.Plugin):
 
         env.addPackage('locscale', version='0.1',
                        tar='locscale-0.1.tgz',
-                       commands=[('echo "installing mpi4py in eman2" ; '
+                       commands=[('echo ; echo " > Installing mpi4py in eman2" ; '
                                   'export %s ; pip install mpi4py' % EMAN_ENV_STR,
                                   emanPlugin.getHome('lib', 'python2.7',
                                                      'site-packages', 'mpi4py'))],

--- a/locscale/constants.py
+++ b/locscale/constants.py
@@ -26,15 +26,23 @@
 # **************************************************************************
 
 from pyworkflow.utils import importFromPlugin
-
+from pyworkflow.install.funcs import Environment
+from os.path import relpath
 
 # we declarate global constants to multiple usage
 LOCSCALE_HOME_VAR = 'LOCSCALE_HOME'
 LOCSCALE_EMAN_HOME_VAR = 'LOCSCALE_EMAN_HOME'
 
-EMAN_HOME_DEFAULT = "eman-2.12"  # FIXME: it should be
-                                 #  importFromPlugin('eman2', 'Plugin').getHome()
-                                 #  but 2.21 fails with MPI...
+# --- Eman2 dependencies ---
+emanPlugin = importFromPlugin('eman2', 'Plugin')
+
+# to get something like 'eman-2.3'
+EMAN_HOME_DEFAULT = relpath(emanPlugin.getHome(), Environment.getEmFolder())
+
+# to set the Eman2 environ in a bash-shell
+EMAN_ENV_STR = ' '.join(['%s=%s' % (var, emanPlugin.getEnviron()[var])
+                         for var in ('PATH', 'PYTHONPATH', 'LD_LIBRARY_PATH',
+                                     'SCIPION_MPI_FLAGS')])
 
 # Supported versions
 V0_1 = '0.1'
@@ -43,5 +51,6 @@ V0_1 = '0.1'
 V2_11 = '2.11'
 V2_12 = '2.12'
 V2_21 = '2.21'
+V2_3 = '2.3'
 
 

--- a/locscale/constants.py
+++ b/locscale/constants.py
@@ -29,7 +29,6 @@ from pyworkflow.utils import importFromPlugin
 
 
 LOCSCALE_HOME = 'LOCSCALE_HOME'
-LOCSCALE_EMAN_HOME = 'LOCSCALE_EMAN_HOME'
 
 # --- Eman2 dependencies ---
 emanPlugin = importFromPlugin('eman2', 'Plugin')

--- a/locscale/convert.py
+++ b/locscale/convert.py
@@ -83,7 +83,7 @@ def getEmanPythonProgram(program):
 
     # locscale scripts are in $LOCSCALE_HOME/source
     program = os.path.join(Plugin.getHome(), 'source', program)
-    python = emanPlugin.getProgram('', True).split(' ')[0]
+    python = os.path.join(Plugin.getVar(LOCSCALE_EMAN_HOME), 'bin', 'python')
 
     return python, program, env
 

--- a/locscale/convert.py
+++ b/locscale/convert.py
@@ -26,12 +26,11 @@
 
 import os
 
-from pyworkflow.utils import Environ, replaceBaseExt, importFromPlugin
+from pyworkflow.utils import replaceBaseExt
 from pyworkflow.em.convert import ImageHandler
+
 from locscale.constants import *
 from locscale import Plugin
-
-emanPlugin = importFromPlugin("eman2", "Plugin")
 
 
 def getVersion():
@@ -51,7 +50,7 @@ def getSupportedVersions():
 def getSupportedEmanVersions():
     """ LocScale needs eman to work.
     """
-    return [V2_11, V2_12]
+    return [V2_11, V2_12, V2_3]
 
 
 def getEmanVersion():
@@ -77,24 +76,8 @@ def validateEmanVersion(errors):
     return errors
 
 
-def getEmanEnviron():
-    """ Setup the environment variables needed to launch Eman and
-        use its modules.
-    """
-    env = Environ(os.environ)
-    emanHome = getEmanVersion()
-    pathList = [os.path.join(emanHome, d)
-                for d in ['lib', 'bin', 'extlib/site-packages']]
-
-    env.update({'PATH': os.path.join(emanHome, 'bin'),
-                'LD_LIBRARY_PATH': os.pathsep.join(pathList),
-                'PYTHONPATH': os.pathsep.join(pathList)},
-               position=Environ.BEGIN)
-
-    return env
-
 def getEmanPythonProgram(program):
-    env = getEmanEnviron()  # FIXME: This should be emanPlugin.getEnviron(), but MPI fails...
+    env = emanPlugin.getEnviron()
 
     # locscale scripts are in $LOCSCALE_HOME/source
     program = os.path.join(Plugin.getHome(), 'source', program)

--- a/locscale/convert.py
+++ b/locscale/convert.py
@@ -26,13 +26,12 @@
 
 import os
 
-from pyworkflow.utils import Environ, replaceBaseExt, importFromPlugin
+from eman2 import EMAN2_HOME
+from pyworkflow.utils import replaceBaseExt
 from pyworkflow.em.convert import ImageHandler
 
 from locscale.constants import *
 from locscale import Plugin
-
-emanPlugin = importFromPlugin("eman2", "Plugin")
 
 
 def getVersion():
@@ -58,7 +57,7 @@ def getSupportedEmanVersions():
 def getEmanVersion():
     """ Returns a valid eman version installed or an empty string.
     """
-    emanVersion = Plugin.getVar(LOCSCALE_EMAN_HOME)
+    emanVersion = emanPlugin.getVar(EMAN2_HOME)
     if os.path.exists(emanVersion):
         return emanVersion
     return ''
@@ -82,8 +81,8 @@ def getEmanPythonProgram(program):
     env = emanPlugin.getEnviron()
 
     # locscale scripts are in $LOCSCALE_HOME/source
-    program = os.path.join(Plugin.getHome(), 'source', program)
-    python = os.path.join(Plugin.getVar(LOCSCALE_EMAN_HOME), 'bin', 'python')
+    program = Plugin.getHome('source', program)
+    python = emanPlugin.getProgram('', True).split(' ')[0]
 
     return python, program, env
 

--- a/locscale/convert.py
+++ b/locscale/convert.py
@@ -26,7 +26,6 @@
 
 import os
 
-from eman2 import EMAN2_HOME
 from pyworkflow.utils import replaceBaseExt
 from pyworkflow.em.convert import ImageHandler
 
@@ -57,9 +56,9 @@ def getSupportedEmanVersions():
 def getEmanVersion():
     """ Returns a valid eman version installed or an empty string.
     """
-    emanVersion = emanPlugin.getVar(EMAN2_HOME)
+    emanVersion = emanPlugin.getHome()
     if os.path.exists(emanVersion):
-        return emanVersion
+        return emanVersion.split('-')[-1]
     return ''
 
 
@@ -70,7 +69,7 @@ def validateEmanVersion(errors):
         protocol: the input protocol calling to validate
         errors: a list that will be used to add the error message.
     """
-    if getEmanVersion() == '':
+    if getEmanVersion() not in getSupportedEmanVersions():
         errors.append('EMAN2 is needed to execute this protocol. '
                       'Install one of the following versions: %s.'
                       % ', '.join(getSupportedEmanVersions()))


### PR DESCRIPTION
I'm doing this PR to the **update-version** branch in order to propose changes. Find below the list of proposals sorted by importance (under my point of view).

- [ ] Locscale needs mpi4py to run in parallel, now Eman haven't it installed, for that reason the MPI tests are failing. I propose to install mpi4py in Eman2 when LocScale is installing to skip the problem.

- [ ] Additionally, I've realized that we have ignoring the `LOCSCALE_EMAN_HOME` and we are using the python from the original Eman (`emanPlugin.getProgram...`). So, I propose to avoid double installation of Eman.

- [ ] Finally, I've realized that we was only checking if the Eman2 is existing but we are not checking for the Supported versions.